### PR TITLE
Fixing access to SMA.long property

### DIFF
--- a/strategies/RSI_BULL_BEAR_ADX.js
+++ b/strategies/RSI_BULL_BEAR_ADX.js
@@ -74,7 +74,7 @@ var strat = {
 		log.info("Make sure your warmup period matches SMA_long and that Gekko downloads data if needed");
 		
 		// warn users
-		if( this.requiredHistory < this.settings.SMA_long )
+		if( this.requiredHistory < this.settings.SMA.long )
 		{
 			log.warn("*** WARNING *** Your Warmup period is lower then SMA_long. If Gekko does not download data automatically when running LIVE the strategy will default to BEAR-mode until it has enough data.");
 		}


### PR DESCRIPTION
Fixing access to SMA.long setting. In the original strategy the setting was actually referenced under SMA_long. 